### PR TITLE
Removed Link from landing page 

### DIFF
--- a/Takeiros-React/src/LandingPage.jsx
+++ b/Takeiros-React/src/LandingPage.jsx
@@ -8,10 +8,7 @@ function LandingPage() {
       <div className="landing-page">
         
          {/* Import and Add Links Here */}
-         <Link to="/">
             <HappyHourSpecials />
-         </Link>
-         
       </div>
    )
 }


### PR DESCRIPTION
Removed the Link To from the Landing Page as it is not needed. We just want to display the components; they don't need to be linked. 